### PR TITLE
Delete github acdess token

### DIFF
--- a/.github/workflows/aws_k8s_terratest.yml
+++ b/.github/workflows/aws_k8s_terratest.yml
@@ -14,7 +14,6 @@ jobs:
       TF_VERSION: 0.12.29
       DOCKERHUB_USER: scalartest
       DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     defaults:
       run:
         working-directory: ./test
@@ -50,7 +49,7 @@ jobs:
 
       - name: Clone scalar-terraform-examples
         run: |
-          git clone -b main --depth 1 https://git:${GIT_ACCESS_TOKEN}@github.com/scalar-labs/scalar-terraform-examples modules
+          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -12,7 +12,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TF_VERSION: 0.12.29
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     defaults:
       run:
         working-directory: ./test
@@ -48,7 +47,7 @@ jobs:
 
       - name: Clone scalar-terraform-examples
         run: |
-          git clone -b main --depth 1 https://git:${GIT_ACCESS_TOKEN}@github.com/scalar-labs/scalar-terraform-examples modules
+          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -16,7 +16,6 @@ jobs:
       TF_VERSION: 0.12.29
       DOCKERHUB_USER: scalartest
       DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     defaults:
       run:
         working-directory: ./test
@@ -52,7 +51,7 @@ jobs:
 
       - name: Clone scalar-terraform-examples
         run: |
-          git clone -b main --depth 1 https://git:${GIT_ACCESS_TOKEN}@github.com/scalar-labs/scalar-terraform-examples modules
+          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -14,7 +14,6 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
       TF_VERSION: 0.12.29
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     defaults:
       run:
         working-directory: ./test
@@ -50,7 +49,7 @@ jobs:
 
       - name: Clone scalar-terraform-examples
         run: |
-          git clone -b main --depth 1 https://git:${GIT_ACCESS_TOKEN}@github.com/scalar-labs/scalar-terraform-examples modules
+          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/test/src/integration/integration_test.go
+++ b/test/src/integration/integration_test.go
@@ -178,12 +178,9 @@ func runAnsiblePlaybook(t *testing.T, playbookOptions []string) {
 }
 
 func gitClone(t *testing.T, repo string) {
-	// Remove the access token when the scalar-k8s repository is published
-	token := os.Getenv("GIT_ACCESS_TOKEN")
-
 	gitCommand := shell.Command{
 		Command:    "git",
-		Args:       []string{"clone", "-b", "master", "--depth", "1", "https://git:" + token + "@github.com/" + repo },
+		Args:       []string{"clone", "-b", "master", "--depth", "1", "https://github.com/" + repo },
 		WorkingDir: "./",
 	}
 


### PR DESCRIPTION
# Description

`GAT` is no longer needed since `scalar-kubernetes` and `scalar-terraform-xampes` have been published.