### PR TITLE
Add tcp check

### DIFF
--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -3,9 +3,9 @@ package test
 import (
 	"fmt"
 	"io/ioutil"
-	"testing"
-	"os"
 	"net"
+	"os"
+	"testing"
 	"time"
 
 	"modules/grpc_helper"
@@ -46,7 +46,7 @@ func TestScalarDLWithJavaClientExpectStatusCodeIsValid(t *testing.T) {
 	logger.Logf(t, "URL: %s", scalarurl)
 	writePropertiesFile(t, scalarurl)
 
-	if ! isReachable(t, scalarurl + ":50051") {
+	if !isReachable(t, scalarurl+":50051") {
 		t.Fatal("Unreachable")
 	}
 
@@ -129,7 +129,7 @@ func isReachable(t *testing.T, host string) bool {
 	checkInterval := 10
 	status := false
 
-	for i := 0; i <= numRetries; i ++ {
+	for i := 0; i <= numRetries; i++ {
 		conn, err := net.Dial("tcp", host)
 		if err != nil {
 			logger.Logf(t, "Connection check fail")

--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -46,8 +46,7 @@ func TestScalarDLWithJavaClientExpectStatusCodeIsValid(t *testing.T) {
 	logger.Logf(t, "URL: %s", scalarurl)
 	writePropertiesFile(t, scalarurl)
 
-	err := isReachable(t, scalarurl + ":50051")
-	if err != "OK" {
+	if ! isReachable(t, scalarurl + ":50051") {
 		t.Fatal(err)
 	}
 
@@ -123,24 +122,25 @@ func getExternalIP(t *testing.T) string {
 	return output
 }
 
-func isReachable(t *testing.T, host string) string {
+func isReachable(t *testing.T, host string) bool {
 	logger.Logf(t, "Check tcp connection: %s", host)
 
-	timeout := 10 * 60
-	status := "NG"
+	numRetries := 60
+	checkInterval := 10
+	status := false
 
-	for i := 0; i <= timeout; i += 10 {
+	for i := 0; i <= numRetries; i ++ {
 		conn, err := net.Dial("tcp", host)
 		if err != nil {
 			logger.Logf(t, "Connection check fail")
 		} else {
 			logger.Logf(t, "Connection check OK")
-			status = "OK"
+			status = true
 			defer conn.Close()
 			break
 		}
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(checkInterval * time.Second)
 	}
 
 	return status

--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -127,7 +127,6 @@ func isReachable(t *testing.T, host string) bool {
 
 	numRetries := 60
 	checkInterval := 10
-	status := false
 
 	for i := 0; i <= numRetries; i++ {
 		conn, err := net.Dial("tcp", host)
@@ -135,13 +134,12 @@ func isReachable(t *testing.T, host string) bool {
 			logger.Logf(t, "Connection check fail")
 		} else {
 			logger.Logf(t, "Connection check OK")
-			status = true
 			defer conn.Close()
-			break
+			return true
 		}
 
 		time.Sleep(time.Duration(checkInterval) * time.Second)
 	}
 
-	return status
+	return false
 }

--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -47,7 +47,7 @@ func TestScalarDLWithJavaClientExpectStatusCodeIsValid(t *testing.T) {
 	writePropertiesFile(t, scalarurl)
 
 	if ! isReachable(t, scalarurl + ":50051") {
-		t.Fatal(err)
+		t.Fatal("Unreachable")
 	}
 
 	code, _ := grpc_helper.GrpcJavaRegisterCert(t, propertiesFile)
@@ -140,7 +140,7 @@ func isReachable(t *testing.T, host string) bool {
 			break
 		}
 
-		time.Sleep(checkInterval * time.Second)
+		time.Sleep(time.Duration(checkInterval) * time.Second)
 	}
 
 	return status

--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 	"os"
+	"net"
+	"time"
 
 	"modules/grpc_helper"
 
@@ -43,6 +45,11 @@ func TestScalarDLWithJavaClientExpectStatusCodeIsValid(t *testing.T) {
 
 	logger.Logf(t, "URL: %s", scalarurl)
 	writePropertiesFile(t, scalarurl)
+
+	err := checkTCPConnect(t, scalarurl + ":50051")
+	if err != "OK" {
+		t.Fatal(err)
+	}
 
 	code, _ := grpc_helper.GrpcJavaRegisterCert(t, propertiesFile)
 	assert.Contains(t, expectedRegisterCertStatusCode, code)
@@ -114,4 +121,27 @@ func getExternalIP(t *testing.T) string {
 	logger.Logf(t, "URL: %s", output)
 
 	return output
+}
+
+func checkTCPConnect(t *testing.T, host string) string {
+	logger.Logf(t, "Check tcp connection: %s", host)
+
+	timeout := 10 * 60
+	status := "NG"
+
+	for i := 0; i <= timeout; i += 10 {
+			conn, err := net.Dial("tcp", host)
+			if err != nil {
+				logger.Logf(t, "Connection check fail")
+			} else {
+					logger.Logf(t, "Connection check OK")
+					status = "OK"
+					defer conn.Close()
+					break
+			}
+
+			time.Sleep(10 * time.Second)
+	}
+
+	return status
 }

--- a/test/src/integration/integration_scalardl_test.go
+++ b/test/src/integration/integration_scalardl_test.go
@@ -46,7 +46,7 @@ func TestScalarDLWithJavaClientExpectStatusCodeIsValid(t *testing.T) {
 	logger.Logf(t, "URL: %s", scalarurl)
 	writePropertiesFile(t, scalarurl)
 
-	err := checkTCPConnect(t, scalarurl + ":50051")
+	err := isReachable(t, scalarurl + ":50051")
 	if err != "OK" {
 		t.Fatal(err)
 	}
@@ -123,24 +123,24 @@ func getExternalIP(t *testing.T) string {
 	return output
 }
 
-func checkTCPConnect(t *testing.T, host string) string {
+func isReachable(t *testing.T, host string) string {
 	logger.Logf(t, "Check tcp connection: %s", host)
 
 	timeout := 10 * 60
 	status := "NG"
 
 	for i := 0; i <= timeout; i += 10 {
-			conn, err := net.Dial("tcp", host)
-			if err != nil {
-				logger.Logf(t, "Connection check fail")
-			} else {
-					logger.Logf(t, "Connection check OK")
-					status = "OK"
-					defer conn.Close()
-					break
-			}
+		conn, err := net.Dial("tcp", host)
+		if err != nil {
+			logger.Logf(t, "Connection check fail")
+		} else {
+			logger.Logf(t, "Connection check OK")
+			status = "OK"
+			defer conn.Close()
+			break
+		}
 
-			time.Sleep(10 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 
 	return status

--- a/test/src/integration/integration_test.go
+++ b/test/src/integration/integration_test.go
@@ -107,7 +107,7 @@ func TestEndToEndK8s(t *testing.T) {
 	test_structure.RunTestStage(t, "ansible", func() {
 		logger.Logf(t, "Run Ansible playbooks")
 		runAnsiblePlaybooks(t)
-		time.Sleep(300 * time.Second)
+		time.Sleep(120 * time.Second)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7873

# Done
Add tcp check. (timeout: `10min`)

# Confirm
```
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T12:59:36+09:00 integration_scalardl_test.go:127: Check tcp connection: a83b2147404e944778ce7cf65229cf46-7a0ac819b34b1633.elb.us-east-1.amazonaws.com:50051
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T12:59:36+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T12:59:46+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T12:59:56+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:00:06+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:00:16+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:00:26+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:00:36+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:00:46+09:00 integration_scalardl_test.go:135: Connection check fail
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:11+09:00 integration_scalardl_test.go:137: Connection check OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:11+09:00 grpc_helper.go:73: Starting Java register-cert [--properties ./resources/test.properties]
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:14+09:00 grpc_helper.go:91: OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:14+09:00 grpc_helper.go:92:
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:14+09:00 grpc_helper.go:73: Starting Java register-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./resources/StateUpdater.class]
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:47+09:00 grpc_helper.go:91: OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:47+09:00 grpc_helper.go:92:
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:02:47+09:00 grpc_helper.go:73: Starting Java execute-contract [--properties ./resources/test.properties --contract-id test-contract1 --contract-argument {"asset_id": "over9000", "state": 9001}]
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:08+09:00 grpc_helper.go:91: OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:08+09:00 grpc_helper.go:92:
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:08+09:00 grpc_helper.go:73: Starting Java validate-ledger [--properties ./resources/test.properties --asset-id over9000]
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:11+09:00 grpc_helper.go:91: OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:11+09:00 grpc_helper.go:92:
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:11+09:00 grpc_helper.go:73: Starting Java list-contracts [--properties ./resources/test.properties]
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:13+09:00 grpc_helper.go:91: OK
TestEndToEndK8s/TestScalarDL/scalardl/ScalarDLWithJavaClient 2021-01-25T13:03:13+09:00 grpc_helper.go:92:
```