### PR TITLE
Fix to use checkout to clone scalar-terraform-examples

### DIFF
--- a/.github/workflows/aws_k8s_terratest.yml
+++ b/.github/workflows/aws_k8s_terratest.yml
@@ -47,9 +47,12 @@ jobs:
           go-version: 1.15.5
         id: go
 
-      - name: Clone scalar-terraform-examples
-        run: |
-          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
+      - name: Checkout scalar-terraform-examples
+        uses: actions/checkout@v2
+        with:
+          repository: scalar-labs/scalar-terraform-examples
+          ref: main
+          path: ./test/modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -46,9 +46,12 @@ jobs:
           go-version: 1.15.5
         id: go
 
-      - name: Clone scalar-terraform-examples
-        run: |
-          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
+      - name: Checkout scalar-terraform-examples
+        uses: actions/checkout@v2
+        with:
+          repository: scalar-labs/scalar-terraform-examples
+          ref: main
+          path: ./test/modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -49,9 +49,12 @@ jobs:
           go-version: 1.15.5
         id: go
 
-      - name: Clone scalar-terraform-examples
-        run: |
-          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
+      - name: Checkout scalar-terraform-examples
+        uses: actions/checkout@v2
+        with:
+          repository: scalar-labs/scalar-terraform-examples
+          ref: main
+          path: ./test/modules
 
       - name: Copy custom terraform.tfvars
         run: |

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -48,9 +48,12 @@ jobs:
           go-version: 1.15.5
         id: go
 
-      - name: Clone scalar-terraform-examples
-        run: |
-          git clone -b main --depth 1 https://github.com/scalar-labs/scalar-terraform-examples modules
+      - name: Checkout scalar-terraform-examples
+        uses: actions/checkout@v2
+        with:
+          repository: scalar-labs/scalar-terraform-examples
+          ref: main
+          path: ./test/modules
 
       - name: Copy custom terraform.tfvars
         run: |


### PR DESCRIPTION
# Description

Fix to use `actions/checkout@v2` to clone `scalar-terraform-examples`