### PR TITLE
Add setup java for github actions

### DIFF
--- a/.github/workflows/aws_k8s_terratest.yml
+++ b/.github/workflows/aws_k8s_terratest.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+          java-package: jre
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/aws_k8s_terratest.yml
+++ b/.github/workflows/aws_k8s_terratest.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+          java-package: jre
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+          java-package: jre
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -3,9 +3,6 @@ name: Integration-test-with-terratest-for-Azure
 on:
   schedule:
     - cron: 0 15 * * *
-  pull_request:
-    branches:
-      - master
 
 jobs:
   terratest:

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+          java-package: jre
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -3,6 +3,9 @@ name: Integration-test-with-terratest-for-Azure
 on:
   schedule:
     - cron: 0 15 * * *
+  pull_request:
+    branches:
+      - master
 
 jobs:
   terratest:


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-8602
https://scalar-labs.atlassian.net/browse/DLT-8603
https://scalar-labs.atlassian.net/browse/DLT-8604

Default java version is `11` in `Ubuntu-20.04`
https://github.com/actions/virtual-environments/issues/1816

# Done
Fix to use java `8` instead of default version `11`.