### PR TITLE
Fix custom config path for k8s test

### DIFF
--- a/test/src/integration/integration_test.go
+++ b/test/src/integration/integration_test.go
@@ -169,7 +169,7 @@ func runAnsiblePlaybooks(t *testing.T) {
 	runAnsiblePlaybook(t, k8sModuleDir, "../inventories", []string{"./playbooks/playbook-install-tools.yml", "-e", "base_local_directory=../../../../"})
 
 	// Deploy scalardl
-	runAnsiblePlaybook(t, k8sModuleDir, "../inventories", []string{"./playbooks/playbook-deploy-scalardl.yml", "-e", "base_local_directory=../../../conf"})
+	runAnsiblePlaybook(t, k8sModuleDir, "../inventories", []string{"./playbooks/playbook-deploy-scalardl.yml", "-e", "local_helm_charts_values_directory=../../../conf"})
 }
 
 func runGoss(t *testing.T, targetModules []string, targetHosts string) {


### PR DESCRIPTION
# Description

refs: https://github.com/scalar-labs/scalar-kubernetes/pull/116

# Done
Fix var name to `local_helm_charts_values_directory` for `custom config path`