### PR TITLE
Fix ansible-base package name to ansible-core

### DIFF
--- a/.github/workflows/aws_k8s_terratest.yml
+++ b/.github/workflows/aws_k8s_terratest.yml
@@ -35,7 +35,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Install dependencies
-        run: pipx inject ansible-base jmespath
+        run: pipx inject ansible-core jmespath
 
       - name: Download scalardl client sdk
         run: |

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -3,6 +3,9 @@ name: Integration-test-with-terratest-for-Azure-Kubernetes
 on:
   schedule:
     - cron: 0 17 * * *
+  pull_request:
+    branches:
+      - master
 
 jobs:
   terratest:

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -3,9 +3,6 @@ name: Integration-test-with-terratest-for-Azure-Kubernetes
 on:
   schedule:
     - cron: 0 17 * * *
-  pull_request:
-    branches:
-      - master
 
 jobs:
   terratest:

--- a/.github/workflows/azure_k8s_terratest.yml
+++ b/.github/workflows/azure_k8s_terratest.yml
@@ -37,7 +37,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Install dependencies
-        run: pipx inject ansible-base jmespath
+        run: pipx inject ansible-core jmespath
 
       - name: Download scalardl client sdk
         run: |


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-9542
https://scalar-labs.atlassian.net/browse/DLT-9545

The action runner image has been updated and ansible has been upgraded to 2.11.x.
https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210718.1

https://docs.ansible.com/ansible-core/devel/roadmap/ROADMAP_2_11.html
Rename `ansible-base` to `ansible-core`.