### PR TITLE
Disable terraform tests

### DIFF
--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -1,8 +1,6 @@
 name: Integration-test-with-terratest-for-AWS
 
-on:
-  schedule:
-    - cron: 0 15 * * *
+on: workflow_dispatch
 
 jobs:
   terratest:

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -1,8 +1,6 @@
 name: Integration-test-with-terratest-for-Azure
 
-on:
-  schedule:
-    - cron: 0 15 * * *
+on: workflow_dispatch
 
 jobs:
   terratest:


### PR DESCRIPTION
Disable terraform tests since we don't really use terraform-created environments.
Keeping k8s based tests since they check if the helm charts work fine.